### PR TITLE
Help text

### DIFF
--- a/web/theme/templates/pages/help/schema_001.md
+++ b/web/theme/templates/pages/help/schema_001.md
@@ -1,1 +1,5 @@
-Sadly, we don't have a help section for this report finding ... *yet*.
+The number of column headings in the header row does not match the number of fields defined in the schema.
+
+- Check that your data does not have an extra header row preceding the header row containing the column headings
+- Check that your header row is not missing, or has an extra comma between the column headings
+- Check that your schema defines the correct number of fields for your data

--- a/web/theme/templates/pages/help/schema_001.md
+++ b/web/theme/templates/pages/help/schema_001.md
@@ -1,5 +1,6 @@
 The number of column headings in the header row does not match the number of fields defined in the schema.
 
-- Check that your data does not have an extra header row preceding the header row containing the column headings
-- Check that your header row is not missing, or has an extra comma between the column headings
-- Check that your schema defines the correct number of fields for your data
+Things you can try:
+- Check that your data does not have an extra row preceding the header row containing the column headings. 
+- Check that the header row in the data is not missing, or has an extra comma between the column headings.
+- Check that your schema defines the correct number of fields for your data.

--- a/web/theme/templates/pages/help/schema_001.md
+++ b/web/theme/templates/pages/help/schema_001.md
@@ -2,5 +2,5 @@ The number of column headings in the header row does not match the number of fie
 
 Things you can try:
 - Check that your data does not have an extra row preceding the header row containing the column headings. 
-- Check that the header row in the data is not missing, or has an extra comma between the column headings.
+- Check that the header row in the data is not missing a comma, or has an extra comma, between the column headings.
 - Check that your schema defines the correct number of fields for your data.

--- a/web/theme/templates/pages/help/schema_002.md
+++ b/web/theme/templates/pages/help/schema_002.md
@@ -1,3 +1,6 @@
 This row has a different number of columns compared to the header row (the first row in your data).
 
-A key [concept](http://specs.frictionlessdata.io/json-table-schema/#concepts) is that all rows in your tabular data must have the same number of fields (columns). Your data may have a missing or extra delimiter between the fields in this row. The delimiter in a comma separated value (.csv) file is a comma `,`.
+A key [concept](http://specs.frictionlessdata.io/json-table-schema/#concepts) is that all the rows in your tabular data must have the same number of fields (columns). 
+
+Things you can try:
+- Check your data is not missing a comma, or has an extra comma, between the fields in this row. 

--- a/web/theme/templates/pages/help/schema_002.md
+++ b/web/theme/templates/pages/help/schema_002.md
@@ -1,1 +1,3 @@
-Sadly, we don't have a help section for this report finding ... *yet*.
+This row has a different number of columns compared to the header row (the first row in your data).
+
+A key [concept](http://specs.frictionlessdata.io/json-table-schema/#concepts) is that all rows in your tabular data must have the same number of fields (columns). Your data may have a missing or extra delimiter between the fields in this row. The delimiter in a comma separated value (.csv) file is a comma `,`.

--- a/web/theme/templates/pages/help/schema_002.md
+++ b/web/theme/templates/pages/help/schema_002.md
@@ -4,3 +4,4 @@ A key [concept](http://specs.frictionlessdata.io/json-table-schema/#concepts) is
 
 Things you can try:
 - Check your data is not missing a comma, or has an extra comma, between the fields in this row. 
+- Check that your schema defines the correct number of fields for your data.

--- a/web/theme/templates/pages/help/schema_003.md
+++ b/web/theme/templates/pages/help/schema_003.md
@@ -1,3 +1,5 @@
 The data does not match the [field type and format](http://specs.frictionlessdata.io/json-table-schema/#field-types-and-formats) you have specified in the JSON Table Schema.
 
-Correct the data to match the field type and format. If the data is correct, adjust the field type and/or format to allow the data to pass the test.
+Things you can try:
+- Correct the data to match the field type and format. 
+- If the data is correct, adjust the field type and/or format to allow the data to pass the test.

--- a/web/theme/templates/pages/help/schema_003.md
+++ b/web/theme/templates/pages/help/schema_003.md
@@ -1,1 +1,3 @@
-Sadly, we don't have a help section for this report finding ... *yet*.
+The data does not match the [field type and format](http://specs.frictionlessdata.io/json-table-schema/#field-types-and-formats) you have specified in the JSON Table Schema.
+
+Correct the data to match the field type and format. If the data is correct, adjust the field type and/or format to allow the data to pass the test.

--- a/web/theme/templates/pages/help/schema_004.md
+++ b/web/theme/templates/pages/help/schema_004.md
@@ -1,1 +1,4 @@
-Sadly, we don't have a help section for this report finding ... *yet*.
+This field is a [required field](http://specs.frictionlessdata.io/json-table-schema/#field-constraints), but it contains no value.
+
+- If you know the missing field value, add it to the data.
+- If the data is not required, remove the `required: true` constraint from your schema or change it to `required: false`.

--- a/web/theme/templates/pages/help/schema_004.md
+++ b/web/theme/templates/pages/help/schema_004.md
@@ -1,4 +1,4 @@
 This field is a [required field](http://specs.frictionlessdata.io/json-table-schema/#field-constraints), but it contains no value.
 
 - If you know the missing field value, add it to the data.
-- If the data is not required, remove the `required: true` constraint from your schema or change it to `required: false`.
+- If the data is not required, remove the `"required": true` constraint from your schema, or change it to `"required": false`.

--- a/web/theme/templates/pages/help/schema_004.md
+++ b/web/theme/templates/pages/help/schema_004.md
@@ -1,4 +1,5 @@
 This field is a [required field](http://specs.frictionlessdata.io/json-table-schema/#field-constraints), but it contains no value.
 
-- If you know the missing field value, add it to the data.
+Things you can try:
+- If you know the missing value, add it to the data.
 - If the data is not required, remove the `"required": true` constraint from your schema, or change it to `"required": false`.

--- a/web/theme/templates/pages/help/schema_005.md
+++ b/web/theme/templates/pages/help/schema_005.md
@@ -1,5 +1,1 @@
-This row is empty. 
-
-Things you can try:
-- Delete the row.
-- choose the `Ignore empty rows` option in Good Tables to prevent empty rows being reported as an error.
+Sadly, we don't have a help section for this report finding ... *yet*.

--- a/web/theme/templates/pages/help/schema_005.md
+++ b/web/theme/templates/pages/help/schema_005.md
@@ -1,1 +1,4 @@
-Sadly, we don't have a help section for this report finding ... *yet*.
+This row is empty. 
+
+- Delete the row, or
+- choose the `Ignore empty rows` option in Good Tables to prevent empty rows being reported as an error.

--- a/web/theme/templates/pages/help/schema_005.md
+++ b/web/theme/templates/pages/help/schema_005.md
@@ -1,4 +1,5 @@
 This row is empty. 
 
-- Delete the row, or
+Things you can try:
+- Delete the row.
 - choose the `Ignore empty rows` option in Good Tables to prevent empty rows being reported as an error.

--- a/web/theme/templates/pages/help/schema_006.md
+++ b/web/theme/templates/pages/help/schema_006.md
@@ -1,4 +1,5 @@
-This field is a [unique field](http://specs.frictionlessdata.io/json-table-schema/#field-constraints), but it contains a value that has been used in another row.
+This field is a [unique field](http://specs.frictionlessdata.io/json-table-schema/#field-constraints) but it contains a value that has been used in another row.
 
-- If you know the correct field value, update the data.
-- If the data in this column is not unique, remove the `"unique": true` constraint from your schema, or change it to `"unique": false`.
+Things you can try:
+- If you know the correct value, update the data.
+- If the data is correct, then the values in this column are not unique. Remove the `"unique": true` constraint from your schema, or change it to `"unique": false`.

--- a/web/theme/templates/pages/help/schema_006.md
+++ b/web/theme/templates/pages/help/schema_006.md
@@ -1,0 +1,4 @@
+This field is a [unique field](http://specs.frictionlessdata.io/json-table-schema/#field-constraints), but it contains a value that has been used in another row.
+
+- If you know the correct field value, update the data.
+- If the data in this column is not unique, remove the `"unique": true` constraint from your schema, or change it to `"unique": false`.

--- a/web/theme/templates/pages/help/structure_001.md
+++ b/web/theme/templates/pages/help/structure_001.md
@@ -1,1 +1,5 @@
-Sadly, we don't have a help section for this report finding ... *yet*.
+A column in the header row is missing a value. Column names must be provided.
+
+Things you can try:
+- Add the missing column name to the first row of the data.
+- If the first row starts with, or ends with a comma, remove it.

--- a/web/theme/templates/pages/help/structure_002.md
+++ b/web/theme/templates/pages/help/structure_002.md
@@ -1,1 +1,4 @@
-Sadly, we don't have a help section for this report finding ... *yet*.
+Two columns in the header row have the same value. Column names should be unique.
+
+Things you can try:
+- Change the first row of the data so all the column names are unique.

--- a/web/theme/templates/pages/help/structure_003.md
+++ b/web/theme/templates/pages/help/structure_003.md
@@ -1,1 +1,7 @@
-Sadly, we don't have a help section for this report finding ... *yet*.
+This row has a different number of columns compared to the header row (the first row in your data).
+
+A key [concept](http://specs.frictionlessdata.io/json-table-schema/#concepts) is that all the rows in your tabular data must have the same number of fields (columns). 
+
+Things you can try:
+- Check your data is not missing a comma, or has an extra comma, between the fields in this row. 
+- Check that your schema defines the correct number of fields for your data.

--- a/web/theme/templates/pages/help/structure_004.md
+++ b/web/theme/templates/pages/help/structure_004.md
@@ -1,1 +1,6 @@
-Sadly, we don't have a help section for this report finding ... *yet*.
+The exact same data has been seen in another row.
+
+Things you can try:
+- If some of the data is incorrect, correct it.
+- If the whole row is an incorrect duplicate, remove it.
+- If the data is correct, choose the `Ignore duplicate rows` option in Good Tables to prevent duplicate rows being reported as an error.

--- a/web/theme/templates/pages/help/structure_005.md
+++ b/web/theme/templates/pages/help/structure_005.md
@@ -2,4 +2,4 @@ This row is empty.
 
 Things you can try:
 - Delete the row.
-- Choose the Ignore empty rows option in Good Tables to prevent empty rows being reported as an error.
+- Choose the `Ignore empty rows` option in Good Tables to prevent empty rows being reported as an error.

--- a/web/theme/templates/pages/help/structure_005.md
+++ b/web/theme/templates/pages/help/structure_005.md
@@ -1,1 +1,5 @@
-Sadly, we don't have a help section for this report finding ... *yet*.
+This row is empty.
+
+Things you can try:
+- Delete the row.
+- Choose the Ignore empty rows option in Good Tables to prevent empty rows being reported as an error.


### PR DESCRIPTION
I've made a start on improving the help. 
- I had to add a missing file for the Unique Field error message - schema_006.md 
- Some help files are missing e.g. http_404_error which was referenced when I ran [this test](http://goodtables.okfnlabs.org/reports?data_url=https%3A%2F%2Fraw.githubusercontent.com%2FStephen-Gates%2FGTFS%2Fmaster%2Ftests%2Fcalendar_dates.txt&format=csv&encoding=&schema_url=https%3A%2F%2Fraw.githubusercontent.com%2FStephen-Gates%2FGTFS%2Fmaster%2Fschemas%2Fcalendar_dates-schema.json). 
- Some errors seems to be duplicates and perhaps both messages don't need to be reported e.g. [This test](http://goodtables.okfnlabs.org/reports?data_url=https%3A%2F%2Fraw.githubusercontent.com%2FStephen-Gates%2FGTFS%2Fmaster%2Ftests%2Ffeed_info.txt&format=csv&encoding=&schema_url=https%3A%2F%2Fraw.githubusercontent.com%2FStephen-Gates%2FGTFS%2Fmaster%2Fschemas%2Ffeed_info-schema.json) reports both Defective Row (Structure_003.md) and Incorrect Dimensions (Schema_002.md). I made the help text the same for these messages.

![image](https://cloud.githubusercontent.com/assets/9379524/18460011/7e608678-79b1-11e6-9976-13de627a6209.png)

I will try invoke more errors using various test data so I can more help text. Any pointers are welcome.
